### PR TITLE
Fixed FontAwesome icons bug

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,6 +14,7 @@
     	<meta http-equiv="content-language" content="{{ with .Site.LanguageCode }}{{ . }}{{ end }}" />
     	{{ .Hugo.Generator }}
 		<!--[if lte IE 8]><script src="{{ .Site.BaseURL }}js/ie/html5shiv.js"></script><![endif]-->
+		<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" type="text/css">
 		<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/main.css" />
 		<!--[if lte IE 8]><link rel="stylesheet" href="{{ .Site.BaseURL }}/css/ie8.css" /><![endif]-->
 	</head>


### PR DESCRIPTION
When the baseURL was set to 'example.com' and the website was accessed on 'example.com' the FontAwesome icons would show ok, but if it was accessed from 'www.example.com' the icons would show as squares.

This change fixes that issue by linking with the online fontawesome stylesheet instead of the local one.