### PR TITLE
Fix reference to top-level .Site within range context

### DIFF
--- a/layouts/partials/portfolio.html
+++ b/layouts/partials/portfolio.html
@@ -4,7 +4,7 @@
 	<div class="row">
 		{{ range .Site.Params.portfolio.gallery }}
 		<article class="6u 12u$(xsmall) work-item">
-			<a href="{{ .Site.BaseURL }}images/{{ .image }}" class="image fit thumb"><img src="{{ .Site.BaseURL }}images/{{ .thumb }}" alt="" /></a>
+			<a href="{{ $.Site.BaseURL }}images/{{ .image }}" class="image fit thumb"><img src="{{ $.Site.BaseURL }}images/{{ .thumb }}" alt="" /></a>
 			<h3>{{ .title }}</h3>
 			<p>{{ .description | markdownify }}</p>
 		</article>


### PR DESCRIPTION
Accessing top-level .Site from within a range context seems to
nowadays require explicitly referencing the top-level with $.