### PR TITLE
Fix lightbox gallery bug

### DIFF
--- a/layouts/partials/portfolio.html
+++ b/layouts/partials/portfolio.html
@@ -1,5 +1,5 @@
 {{ "<!-- portfolio -->" | safeHTML }}
-<section>
+<section id="two">
 	{{ with .Site.Params.portfolio.title }}<h2>{{ . | markdownify }}</h2>{{ end }}
 	<div class="row">
 		{{ range .Site.Params.portfolio.gallery }}


### PR DESCRIPTION
Add an id of “two” to the portfolio section.  This is used at the end
of main.js for the lightbox gallery function.