### PR TITLE
Add links to portfolio pages

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -59,6 +59,7 @@ paginate = 10
 
 		# The images and thumbnails are stored under static/images
 		# Create and change subfolders as you like
+
 		[[params.portfolio.gallery]]
 			image = "fulls/01.jpg"
 			thumb = "thumbs/01.jpg"
@@ -66,10 +67,11 @@ paginate = 10
 			description = "Lorem ipsum dolor sit amet."
 
 		[[params.portfolio.gallery]]
-			image = "fulls/02.jpg"
 			thumb = "thumbs/02.jpg"
 			title = "Lorem ipsum dolor."
 			description = "Lorem ipsum dolor sit amet."
+			# Adding "link" will create a link rather than a popup image
+			link = "02"
 
 		[[params.portfolio.gallery]]
 			image = "fulls/03.jpg"
@@ -78,10 +80,11 @@ paginate = 10
 			description = "Lorem ipsum dolor sit amet."
 
 		[[params.portfolio.gallery]]
-			image = "fulls/04.jpg"
 			thumb = "thumbs/04.jpg"
 			title = "Lorem ipsum dolor."
 			description = "Lorem ipsum dolor sit amet."
+			# Adding "link" will create a link rather than a popup image
+			link = "04"
 
 		[[params.portfolio.gallery]]
 			image = "fulls/05.jpg"

--- a/exampleSite/content/portfolio/02.md
+++ b/exampleSite/content/portfolio/02.md
@@ -1,0 +1,10 @@
++++
+banner = "banners/placeholder.png"
+categories = ["Lorem"]
+date = "2015-06-24T13:50:46+02:00"
+menu = ""
+tags = []
+title = "Portfolio 2"
++++
+
+Here's a portfolio page!

--- a/exampleSite/content/portfolio/04.md
+++ b/exampleSite/content/portfolio/04.md
@@ -1,0 +1,10 @@
++++
+banner = "banners/placeholder.png"
+categories = ["Lorem"]
+date = "2015-06-24T13:50:46+02:00"
+menu = ""
+tags = []
+title = "Portfolio 4"
++++
+
+Here's another portfolio page!

--- a/layouts/partials/portfolio.html
+++ b/layouts/partials/portfolio.html
@@ -4,7 +4,13 @@
 	<div class="row">
 		{{ range .Site.Params.portfolio.gallery }}
 		<article class="6u 12u$(xsmall) work-item">
-			<a href="{{ $.Site.BaseURL }}images/{{ .image }}" class="image fit thumb"><img src="{{ $.Site.BaseURL }}images/{{ .thumb }}" alt="" /></a>
+
+			{{ if isset . "link" }}
+				<a href="{{ $.Site.BaseURL }}portfolio/{{ .link }}" class="image fit thumb"><img src="{{ $.Site.BaseURL }}images/{{ .thumb }}" alt="" /></a>
+			{{ else }}
+				<a href="{{ $.Site.BaseURL }}images/{{ .image }}" class="image fit thumb js-image"><img src="{{ $.Site.BaseURL }}images/{{ .thumb }}" alt="" /></a>
+			{{ end }}
+			
 			<h3>{{ .title | markdownify }}</h3>
 			<p>{{ .description | markdownify }}</p>
 		</article>

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -105,7 +105,7 @@
 						overlayOpacity: 0.85,
 						popupCloserText: '',
 						popupLoaderText: '',
-						selector: '.work-item a.image',
+						selector: '.work-item a.js-image',
 						usePopupCaption: true,
 						usePopupDefaultStyling: false,
 						usePopupEasyClose: false,


### PR DESCRIPTION
https://github.com/digitalcraftsman/hugo-strata-theme/issues/15

This PR adds the option to link portfolio thumbnails to pages (located in content/portfolio/). 