### PR TITLE
Clear floats on portfolio items

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2442,6 +2442,9 @@
 	.work-item {
 		margin: 0 0 2em 0;
 	}
+		.work-item:nth-child(2n+1) {
+			clear: left;
+		}
 
 		.work-item .image {
 			margin: 0 0 1.5em 0;


### PR DESCRIPTION
In reference to this issue: https://github.com/digitalcraftsman/hugo-strata-theme/issues/28

This adds clear: left to every 3rd, 5th, etc .work-item element.